### PR TITLE
Adding frame prefixes

### DIFF
--- a/gazebo/astra_stereo_s_u3.gazebo.xacro
+++ b/gazebo/astra_stereo_s_u3.gazebo.xacro
@@ -10,11 +10,11 @@
 				<visualize>true</visualize>
 				<update_rate>15</update_rate>
 				<topic>/$(arg robot_name)/astra_stereo_s_${name}/rgb/image_raw</topic>
-				<gz_frame_id>astra2_${name}_link</gz_frame_id>
+				<gz_frame_id>$(arg robot_name)/astra2_${name}_link</gz_frame_id>
 
 				<camera name="astra_stereo_s_u3_${name}_camera">
 					<camera_info_topic>/$(arg robot_name)/astra2_${name}/rgb/camera_info</camera_info_topic>
-					<optical_frame_id>astra2_${name}_optical_frame</optical_frame_id>
+					<optical_frame_id>$(arg robot_name)/astra2_${name}_optical_frame</optical_frame_id>
 					<horizontal_fov>${90.0 * M_PI/180.0}</horizontal_fov>
 					<image>
 						<format>R8G8B8</format>
@@ -33,11 +33,11 @@
 				<visualize>true</visualize>
 				<update_rate>15</update_rate>
 				<topic>/$(arg robot_name)/astra2_${name}/depth/image_raw</topic>
-				<gz_frame_id>astra2_${name}_link</gz_frame_id>
+				<gz_frame_id>$(arg robot_name)/astra2_${name}_link</gz_frame_id>
 
 				<camera>
 					<camera_info_topic>/$(arg robot_name)/astra2_${name}/depth/camera_info</camera_info_topic>
-					<optical_frame_id>astra2_${name}_optical_frame</optical_frame_id>
+					<optical_frame_id>$(arg robot_name)/astra2_${name}_optical_frame</optical_frame_id>
 					<horizontal_fov>1.047</horizontal_fov>
 					<image>
 						<format>R_FLOAT32</format>
@@ -61,9 +61,9 @@
 			<xacro:if value="$(arg semantic_segmentation)">
 				<sensor name="astra2_${name}_segmentation_camera" type="segmentation">
 					<topic>/$(arg robot_name)/astra2_${name}/segmentation</topic>
-					<gz_frame_id>astra2_${name}_link</gz_frame_id>
+					<gz_frame_id>$(arg robot_name)/astra2_${name}_link</gz_frame_id>
 					<camera>
-						<optical_frame_id>astra2_${name}_optical_frame</optical_frame_id>
+						<optical_frame_id>$(arg robot_name)/astra2_${name}_optical_frame</optical_frame_id>
 						<segmentation_type>instance</segmentation_type>
 						<horizontal_fov>${90.0 * M_PI/180.0}</horizontal_fov>
 						<image>

--- a/gazebo/flir_a65_camera.gazebo.xacro
+++ b/gazebo/flir_a65_camera.gazebo.xacro
@@ -6,10 +6,10 @@
             <sensor type="thermal" name="${name}_thermal_cam">
                 <update_rate>9</update_rate>
                 <always_on>true</always_on>
-                <topic>${robot_name}/thermal_camera/image_raw</topic>
-                <gz_frame_id>${name}_optical_frame</gz_frame_id>
+                <topic>$(arg robot_name)/thermal_camera/image_raw</topic>
+                <gz_frame_id>$(arg robot_name)${name}_optical_frame</gz_frame_id>
                 <camera name="${name}">
-                    <camera_info_topic>${robot_name}/${name}/camera_info</camera_info_topic>
+                    <camera_info_topic>$(arg robot_name)/${name}/camera_info</camera_info_topic>
                     <horizontal_fov>${45.0*pi/180.0}</horizontal_fov>
                     <image>
                         <format>R8G8B8</format>

--- a/gazebo/generic_camera.gazebo.xacro
+++ b/gazebo/generic_camera.gazebo.xacro
@@ -7,10 +7,10 @@
         <gazebo reference="${name}_link">
             <sensor type="camera" name="${name}_camera_sensor">
                 <update_rate>${update_rate}</update_rate>
-                <topic>${robot_name}/${name}/image_raw</topic>
-                <gz_frame_id>${name}_optical_frame</gz_frame_id>
+                <topic>$(arg robot_name)/${name}/image_raw</topic>
+                <gz_frame_id>$(arg robot_name)/${name}_optical_frame</gz_frame_id>
                 <camera name="${name}">
-                    <camera_info_topic>${robot_name}/${name}/camera_info</camera_info_topic>
+                    <camera_info_topic>$(arg robot_name)/${name}/camera_info</camera_info_topic>
                     <horizontal_fov>${hfov * M_PI/180.0}</horizontal_fov>
                     <image>
                         <format>${image_format}</format>

--- a/gazebo/insta360_air.gazebo.xacro
+++ b/gazebo/insta360_air.gazebo.xacro
@@ -10,7 +10,7 @@
                 <visualize>true</visualize>
                 <update_rate>15</update_rate>
                 <topic>/$(arg robot_name)/insta360_air_${name}_left/rgb/image_raw</topic>
-                <gz_frame_id>insta360_air_${name}_left_optical_frame</gz_frame_id>
+                <gz_frame_id>$(arg robot_name)/insta360_air_${name}_left_optical_frame</gz_frame_id>
 
                 <camera>
                     <camera_info_topic>/$(arg robot_name)/insta360_air_${name}_left/rgb/camera_info</camera_info_topic>
@@ -40,11 +40,11 @@
                 <visualize>true</visualize>
                 <update_rate>15</update_rate>
                 <topic>/$(arg robot_name)/insta360_air_${name}_right/rgb/image_raw</topic>
-                <gz_frame_id>insta360_air_${name}_right_optical_frame</gz_frame_id>
+                <gz_frame_id>$(arg robot_name)/insta360_air_${name}_right_optical_frame</gz_frame_id>
 
                 <camera>
                     <camera_info_topic>/$(arg robot_name)/insta360_air_${name}_right/rgb/camera_info</camera_info_topic>
-                    <optical_frame_id>insta360_air_${name}_right_optical_frame</optical_frame_id>
+                    <optical_frame_id>$(arg robot_name)/insta360_air_${name}_right_optical_frame</optical_frame_id>
                     <horizontal_fov>${M_PI}</horizontal_fov>
                     <image>
                         <format>R8G8B8</format>

--- a/gazebo/insta360_pro2.gazebo.xacro
+++ b/gazebo/insta360_pro2.gazebo.xacro
@@ -7,11 +7,11 @@
         <gazebo reference="${camera_name}_link">
             <sensor type="wideanglecamera" name="${camera_name}_camera_sensor">
                 <update_rate>${update_rate}</update_rate>
-                <topic>${robot_name}/${camera_name}/${ros_topic}</topic>
-                <gz_frame_id>${camera_name}_optical_frame</gz_frame_id>
+                <topic>$(arg robot_name)/${camera_name}/${ros_topic}</topic>
+                <gz_frame_id>$(arg robot_name)/${camera_name}_optical_frame</gz_frame_id>
                 <camera name="${name}">
                 <!--<horizontal_fov>${hfov * pi/180.0}</horizontal_fov>-->
-                    <camera_info_topic>${robot_name}/${camera_name}/camera_info</camera_info_topic>
+                    <camera_info_topic>$(arg robot_name)/${camera_name}/camera_info</camera_info_topic>
                     <horizontal_fov>${fov}</horizontal_fov>
                     <image>
                         <format>${image_format}</format>

--- a/gazebo/livox_mid360.gazebo.xacro
+++ b/gazebo/livox_mid360.gazebo.xacro
@@ -9,7 +9,7 @@
 				<pose relative_to='livox_mid360_${name}_link'>0 0 0 0 0 0</pose>
 				<topic>/$(arg robot_name)/livox_mid360_${name}</topic>
 				<update_rate>10</update_rate>
-				<gz_frame_id>livox_mid360_${name}_link</gz_frame_id>
+				<gz_frame_id>$(arg robot_name)/livox_mid360_${name}_link</gz_frame_id>
 				<ray>
 					<scan>
 						<horizontal>

--- a/gazebo/orbbec_astra2.gazebo.xacro
+++ b/gazebo/orbbec_astra2.gazebo.xacro
@@ -10,11 +10,11 @@
 				<visualize>true</visualize>
 				<update_rate>15</update_rate>
 				<topic>/$(arg robot_name)/astra2_${name}/rgb/image_raw</topic>
-				<gz_frame_id>astra2_${name}_link</gz_frame_id>
+				<gz_frame_id>$(arg robot_name)/astra2_${name}_link</gz_frame_id>
 
 				<camera name="astra2_${name}_camera">
 					<camera_info_topic>/$(arg robot_name)/astra2_${name}/rgb/camera_info</camera_info_topic>
-					<optical_frame_id>astra2_${name}_optical_frame</optical_frame_id>
+					<optical_frame_id>$(arg robot_name)/astra2_${name}_optical_frame</optical_frame_id>
 					<horizontal_fov>${90.0 * M_PI/180.0}</horizontal_fov>
 					<image>
 						<format>R8G8B8</format>
@@ -33,11 +33,11 @@
 				<visualize>true</visualize>
 				<update_rate>15</update_rate>
 				<topic>/$(arg robot_name)/astra2_${name}/depth/image_raw</topic>
-				<gz_frame_id>astra2_${name}_link</gz_frame_id>
+				<gz_frame_id>$(arg robot_name)/astra2_${name}_link</gz_frame_id>
 
 				<camera>
 					<camera_info_topic>/$(arg robot_name)/astra2_${name}/depth/camera_info</camera_info_topic>
-					<optical_frame_id>astra2_${name}_optical_frame</optical_frame_id>
+					<optical_frame_id>$(arg robot_name)/astra2_${name}_optical_frame</optical_frame_id>
 					<horizontal_fov>1.047</horizontal_fov>
 					<image>
 						<format>R_FLOAT32</format>
@@ -61,9 +61,9 @@
 			<xacro:if value="$(arg semantic_segmentation)">
 				<sensor name="astra2_${name}_segmentation_camera" type="segmentation">
 					<topic>/$(arg robot_name)/astra2_${name}/segmentation</topic>
-					<gz_frame_id>astra2_${name}_link</gz_frame_id>
+					<gz_frame_id>$(arg robot_name)/astra2_${name}_link</gz_frame_id>
 					<camera>
-						<optical_frame_id>astra2_${name}_optical_frame</optical_frame_id>
+						<optical_frame_id>$(arg robot_name)/astra2_${name}_optical_frame</optical_frame_id>
 						<segmentation_type>instance</segmentation_type>
 						<horizontal_fov>${90.0 * M_PI/180.0}</horizontal_fov>
 						<image>

--- a/gazebo/os0_128.gazebo.xacro
+++ b/gazebo/os0_128.gazebo.xacro
@@ -7,8 +7,8 @@
                 <visualize>false</visualize>
                 <always_on>true</always_on>
                 <update_rate>${update_rate}</update_rate>
-                <topic>${robot_name}/${name}/scan</topic>
-                <!--gz_frame_id>${name}_frame</gz_frame_id-->
+                <topic>$(arg robot_name)/${name}/scan</topic>
+                <gz_frame_id>$(arg robot_name)/${name}_frame</gz_frame_id>
                 <lidar>
                     <scan>
                         <horizontal>

--- a/gazebo/realsense_d435_camera.gazebo.xacro
+++ b/gazebo/realsense_d435_camera.gazebo.xacro
@@ -7,11 +7,11 @@
             <sensor type="rgbd_camera" name="${name}">
             <!-- Camera-specific parameters -->
             <update_rate>${update_rate}</update_rate>
-            <topic>${robot_name}/${name}</topic>
-            <gz_frame_id>${name}_${frame_name}_optical_frame</gz_frame_id>
+            <topic>$(arg robot_name)/${name}</topic>
+            <gz_frame_id>$(arg robot_name)/${name}_${frame_name}_optical_frame</gz_frame_id>
             <!-- frameName>${name}_${frame_name}_optical_frame</frameName-->
             <camera name="${name}_color">
-                <camera_info_topic>${robot_name}/${name}/camera_info</camera_info_topic>
+                <camera_info_topic>$(arg robot_name)/${name}/camera_info</camera_info_topic>
                 <horizontal_fov>${69.4 * M_PI/180.0}</horizontal_fov>
                 <image>
                     <format>B8G8R8</format>


### PR DESCRIPTION
Adding frame prefixes allows multiple robots to have sensors with the same name, while being part of the same tf tree.