### PR TITLE
Added RGL lidar model for Livox MID-360 gated by use_rgl argument.

### DIFF
--- a/gazebo/livox_mid360.gazebo.xacro
+++ b/gazebo/livox_mid360.gazebo.xacro
@@ -2,11 +2,8 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- When use_rgl is true the Livox Mid360 is simulated with the GPU-accelerated
        RGL plugin (rgl::RGLServerPluginInstance), which requires the
-       rgl::RGLServerPluginManager to be loaded in the world (see base.world.xacro)
-       and a usable NVIDIA GPU at runtime. Otherwise the native gz gpu_lidar sensor
-       is used. The value is selected automatically by the launch files via
-       hector_gazebo_simulation.rgl.resolve_use_rgl; default false so the package
-       still renders standalone without the RGL plugin present. -->
+       rgl::RGLServerPluginManager to be loaded in the world and a usable NVIDIA
+       GPU at runtime. Otherwise the native gz gpu_lidar sensor is used. -->
   <xacro:arg name="use_rgl" default="false"/>
   <xacro:macro name="livox_mid360_gazebo" params="visualize:=false name:=default">
     <gazebo reference="${name}_laser_frame">

--- a/gazebo/livox_mid360.gazebo.xacro
+++ b/gazebo/livox_mid360.gazebo.xacro
@@ -1,36 +1,64 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="livox_mid360_gazebo" params="visualize:=True name:=default">
+  <!-- When use_rgl is true the Livox Mid360 is simulated with the GPU-accelerated
+       RGL plugin (rgl::RGLServerPluginInstance), which requires the
+       rgl::RGLServerPluginManager to be loaded in the world (see base.world.xacro)
+       and a usable NVIDIA GPU at runtime. Otherwise the native gz gpu_lidar sensor
+       is used. The value is selected automatically by the launch files via
+       hector_gazebo_simulation.rgl.resolve_use_rgl; default false so the package
+       still renders standalone without the RGL plugin present. -->
+  <xacro:arg name="use_rgl" default="false"/>
+  <xacro:macro name="livox_mid360_gazebo" params="visualize:=false name:=default">
     <gazebo reference="${name}_laser_frame">
-      <sensor name="gpu_lidar_${name}" type="gpu_lidar">
-        <pose relative_to="${name}_laser_frame">0 0 0 0 0 0</pose>
-        <topic>/$(arg robot_name)/${name}</topic>
-        <update_rate>10</update_rate>
-        <gz_frame_id>${name}_laser_frame</gz_frame_id>
-        <always_on>1</always_on>
-        <visualize>${visualize}</visualize>
-        <ray>
-          <scan>
-            <horizontal>
-              <samples>100</samples>
-              <resolution>1</resolution>
-              <min_angle>${0}</min_angle>
-              <max_angle>${2*pi}</max_angle>
-            </horizontal>
-            <vertical>
-              <samples>360</samples>
-              <resolution>1</resolution>
-              <min_angle>${radians(-7.22)}</min_angle>
-              <max_angle>${radians(55.22)}</max_angle>
-            </vertical>
-          </scan>
-          <range>
-            <min>0.08</min>
-            <max>10.0</max>
-            <resolution>0.01</resolution>
-          </range>
-        </ray>
-      </sensor>
+      <xacro:if value="$(arg use_rgl)">
+        <!-- RGL publishes the cloud on the exact <topic> (gz appends nothing), so
+             the topic must carry the /points suffix the bridge expects. <frame>
+             sets the PointCloud2 header.frame_id. -->
+        <sensor name="rgl_lidar_${name}" type="custom">
+          <plugin filename="RGLServerPluginInstance" name="rgl::RGLServerPluginInstance">
+            <range>
+              <min>0.08</min>
+              <max>40.0</max>
+            </range>
+            <update_rate>10</update_rate>
+            <update_on_paused_sim>false</update_on_paused_sim>
+            <topic>/$(arg robot_name)/${name}/points</topic>
+            <frame>${name}_laser_frame</frame>
+            <pattern_preset>Livox Mid360</pattern_preset>
+          </plugin>
+        </sensor>
+      </xacro:if>
+      <xacro:unless value="$(arg use_rgl)">
+        <sensor name="gpu_lidar_${name}" type="gpu_lidar">
+          <pose relative_to="${name}_laser_frame">0 0 0 0 0 0</pose>
+          <topic>/$(arg robot_name)/${name}</topic>
+          <update_rate>10</update_rate>
+          <gz_frame_id>${name}_laser_frame</gz_frame_id>
+          <always_on>1</always_on>
+          <visualize>${visualize}</visualize>
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>360</samples>
+                <resolution>1</resolution>
+                <min_angle>${0}</min_angle>
+                <max_angle>${2*pi}</max_angle>
+              </horizontal>
+              <vertical>
+                <samples>48</samples>
+                <resolution>1</resolution>
+                <min_angle>${radians(-7.22)}</min_angle>
+                <max_angle>${radians(55.22)}</max_angle>
+              </vertical>
+            </scan>
+            <range>
+              <min>0.08</min>
+              <max>40.0</max>
+              <resolution>0.01</resolution>
+            </range>
+          </ray>
+        </sensor>
+      </xacro:unless>
     </gazebo>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
Set `use_rgl` to true to use [RGL](https://github.com/tu-darmstadt-ros-pkg/RGLGazeboPlugin) to simulate Livox instead of gpu_lidar for a more realistic lidar pattern.

This also fixes the samples for the gpu_lidar version, which produced twice the points of a normal Livox and swapped vertical and horizontal.